### PR TITLE
[FIX] runbot_restore_db: fix closest branch name for pull requests

### DIFF
--- a/runbot_restore_db/runbot.py
+++ b/runbot_restore_db/runbot.py
@@ -136,7 +136,9 @@ class RunbotBuild(osv.osv):
         result_for = lambda d: (d.repo_id.id, d.name, 'exact')
 
         for build in self.browse(cr, uid, ids, context=context):
-            name = build.branch_id.branch_name
+            branch = build.branch_id
+            pi = branch._get_pull_info()
+            name = pi['base']['ref'] if pi else branch.branch_name
             if name.split('-',1)[0] == "saas":
                 name = "%s-%s" % (name.split('-',1)[0], name.split('-',2)[1])
             else:


### PR DESCRIPTION
Hi Nicolas,

We've having some problem with pull request build being broken, always detecting base Odoo version of 8.0 instead of the correct one base.

This PR re-add base branch detection based on PR infos, this is lamely copied from: 
https://github.com/odoo/odoo-extra/blob/master/runbot/runbot.py#L684-L686

Cheers,
Xavier