### PR TITLE
[FIX] runbot_restore_db: return -2 if job has to be skipped

### DIFF
--- a/runbot_restore_db/runbot.py
+++ b/runbot_restore_db/runbot.py
@@ -68,14 +68,14 @@ class RunbotBuild(osv.osv):
 
     def _job_25_restore(self, cr, uid, build, lock_path, log_path):
         if not build.repo_id.db_name and not build.branch_id.db_name:
-            return 0
+            return -2
         self._local_pg_createdb(cr, uid, "%s-custom" % build.dest)
         cmd = "pg_dump %s | psql %s-custom" % (build.branch_id.db_name or build.repo_id.db_name, build.dest)
         return self._spawn(cmd, lock_path, log_path, cpu_limit=None, shell=True)
 
     def _job_26_upgrade(self, cr, uid, build, lock_path, log_path):
         if not build.repo_id.db_name and not build.branch_id.db_name:
-            return 0
+            return -2
         to_test = build.modules if build.modules and not build.repo_id.force_update_all else 'all'
         cmd, mods = build._cmd()
         cmd += ['-d', '%s-custom' % build.dest, '-u', to_test, '--stop-after-init', '--log-level=info']


### PR DESCRIPTION
Returning -2 instead of 0 when job has to be skipped allow _schedule() method [1]
to immediately start processing the next job, avoiding a 1 minute lag per job.

This avoid a 2min overhead when repo/branch has no customer db to restore

[1]  https://github.com/nseinlet/openerp_runbot_extend/blob/ca228a80834ecd5c65a060e857fbb83b53e38679/runbot_restore_db/runbot.py#L268-L271